### PR TITLE
fix: include current node in scope

### DIFF
--- a/lua/nvim_context_vt.lua
+++ b/lua/nvim_context_vt.lua
@@ -16,9 +16,12 @@ local targets = {
     'class_declaration',
 
     'while_expression',
+    'while_statement',
 
     'for_expression',
     'foreach_statement',
+    'for_statement',
+    'for_in_statement',
 
     -- ruby target
     'class',
@@ -41,6 +44,7 @@ local function setVirtualText(node)
     end
 
 end
+
 function M.showContext(node)
     if node == nil then
         -- Clear the existing.

--- a/lua/nvim_context_vt.lua
+++ b/lua/nvim_context_vt.lua
@@ -7,7 +7,7 @@ local targets = {
     'function',
     'method_declaration',
     'function_declaration',
-    'function_defintion',
+    'function_definition',
     'local_function',
 
     'if_statement',

--- a/lua/nvim_context_vt.lua
+++ b/lua/nvim_context_vt.lua
@@ -1,5 +1,8 @@
 -- This is a pretty simple function that gets the context and up the
 -- tree for the current position.
+
+local ts_utils = require 'nvim-treesitter.ts_utils';
+
 local targets = {
     'function',
     'method_declaration',
@@ -27,9 +30,18 @@ local targets = {
     'for'
 }
 local M = {}
-function M.showContext(node)
-    local ts_utils = require 'nvim-treesitter.ts_utils';
 
+local function setVirtualText(node)
+    if vim.tbl_contains(targets, node:type()) then
+        local targetLineNumber = node:end_();
+
+        local nodeText = ts_utils.get_node_text(node, 0);
+
+        vim.api.nvim_buf_set_virtual_text(0, vim.g.context_vt_namespace, targetLineNumber, {{ "--> " .. nodeText[1], 'Comment' }}, {});
+    end
+
+end
+function M.showContext(node)
     if node == nil then
         -- Clear the existing.
         vim.api.nvim_buf_clear_namespace(0, vim.g.context_vt_namespace, 0, -1);
@@ -43,21 +55,13 @@ function M.showContext(node)
 
     local parentNode = node:parent();
 
+    setVirtualText(node)
     if not parentNode then
         return
     end
+    setVirtualText(parentNode)
 
-    local type = parentNode:type()
-
-    if vim.tbl_contains(targets, type) then
-        local targetLineNumber = parentNode:end_();
-
-        local parentNodeText = ts_utils.get_node_text(parentNode, 0);
-
-        vim.api.nvim_buf_set_virtual_text(0, vim.g.context_vt_namespace, targetLineNumber, {{ "--> " .. parentNodeText[1], 'Comment' }}, {});
-    end
-
-    if not (type == 'program') then
+    if parentNode and not (parentNode:type() == 'program') then
         M.showContext(parentNode);
     end
 end


### PR DESCRIPTION
The current node will also be included.
This works well even for blank lines.

Before:


https://user-images.githubusercontent.com/16581287/116495649-46dc9780-a8de-11eb-883c-c227a6f8f7f2.mp4




After:

https://user-images.githubusercontent.com/16581287/116495194-6a531280-a8dd-11eb-9956-45d67ae3e7c9.mp4

