### PR TITLE
Add setup and virtual text callback to allow user to customize their own virtual text

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,3 +24,27 @@ Install treesitter, then use your favourite package manager.
 
 There are no dependencies.
 
+## Advance usage
+
+You can use a callback to change the virtual text content.
+
+```lua
+require('nvim_context_vt').setup({
+		custom_text_handler = function (node)
+			return "my custom virtual text"
+		end
+	})
+```
+
+If you return `nil`, no virtual text will be displayed. You can use it to filter out node type which you don't to want virtual text to appear.
+
+```lua
+	require('nvim_context_vt').setup({
+		custom_text_handler = function (node)
+            if node:type() == 'function' then
+                return nil
+            end
+			return ts_utils.get_node_text(node)[1]
+		end
+	})
+```


### PR DESCRIPTION
Right now users have no way to customize the virtual text and to decide which node type should the virtual text appears. With the pull request, both of these problems are addressed.