### PR TITLE
feat: debounce CursorMoved* commands

### DIFF
--- a/lua/nvim_context_vt.lua
+++ b/lua/nvim_context_vt.lua
@@ -47,6 +47,8 @@ local targets = {
     'for'
 }
 local M = {}
+local timer = vim.loop.new_timer()
+local debounce_time = 100
 
 local function setVirtualText(node)
     if vim.tbl_contains(targets, node:type()) then
@@ -90,6 +92,18 @@ function M.showContext(node)
     if parentNode and not (parentNode:type() == 'program') then
         M.showContext(parentNode);
     end
+end
+
+function M.onCursorMoved()
+    timer:start(
+        debounce_time,
+        0,
+        vim.schedule_wrap(
+            function()
+                M.showContext()
+            end
+        )
+    )
 end
 
 return M

--- a/plugin/nvim_context_vt.vim
+++ b/plugin/nvim_context_vt.vim
@@ -1,5 +1,4 @@
 let context_vt_namespace = nvim_create_namespace('context_vt')
 
-" Todo: Cache this per line instead of recalculating every move?
-autocmd CursorMoved   * lua require 'nvim_context_vt'.showContext()
-autocmd CursorMovedI   * lua require 'nvim_context_vt'.showContext()
+autocmd CursorMoved   * lua require 'nvim_context_vt'.onCursorMoved()
+autocmd CursorMovedI  * lua require 'nvim_context_vt'.onCursorMoved()


### PR DESCRIPTION
This debounces the `CursorMoved` and `CursorMovedI` commands which should improve performance slightly.