### PR TITLE
Enable to set highlight

### DIFF
--- a/lua/nvim_context_vt.lua
+++ b/lua/nvim_context_vt.lua
@@ -98,7 +98,9 @@ local function setVirtualText(node)
 			return
 		end
 
-        vim.api.nvim_buf_set_virtual_text(0, vim.g.context_vt_namespace, targetLineNumber, {{ virtualText, 'Comment' }}, {});
+        vim.api.nvim_buf_set_extmark(0, vim.g.context_vt_namespace, targetLineNumber, 0, {
+            virt_text = {{virtualText, opts.highlight or 'Comment'}},
+        })
     end
 
 end

--- a/readme.md
+++ b/readme.md
@@ -47,3 +47,12 @@ require('nvim_context_vt').setup {
   end,
 }
 ```
+
+You can set your own highlight for virtual texts.
+
+```lua
+vim.cmd[[hi ContextVt guifg=#365f86]]
+require'nvim_context_vt'.setup{
+  highlight = 'ContextVt',
+}
+```


### PR DESCRIPTION
And use `nvim_buf_set_extmark` instead of deprecated `nvim_buf_set_virtual_text`.