### PR TITLE
refactor: use custom vim highlight group

### DIFF
--- a/lua/nvim_context_vt.lua
+++ b/lua/nvim_context_vt.lua
@@ -105,7 +105,7 @@ local function setVirtualText(node, usedLineNumbers)
 		end
 
         vim.api.nvim_buf_set_extmark(0, vim.g.context_vt_namespace, targetLineNumber, 0, {
-            virt_text = {{virtualText, opts.highlight or 'Comment'}},
+            virt_text = {{virtualText, opts.highlight or 'ContextVt'}},
         })
     end
 

--- a/plugin/nvim_context_vt.vim
+++ b/plugin/nvim_context_vt.vim
@@ -1,5 +1,7 @@
 let context_vt_namespace = nvim_create_namespace('context_vt')
 
+highlight default link ContextVt Comment
+
 " Todo: Cache this per line instead of recalculating every move?
 autocmd CursorMoved   * lua require 'nvim_context_vt'.showContext()
 autocmd CursorMovedI   * lua require 'nvim_context_vt'.showContext()

--- a/readme.md
+++ b/readme.md
@@ -50,9 +50,16 @@ require('nvim_context_vt').setup {
 
 You can set your own highlight for virtual texts.
 
+```vim
+highlight ContextVt guifg=#365f86
+```
+
 ```lua
+-- override internal highlight
 vim.cmd[[hi ContextVt guifg=#365f86]]
+
+-- or use a custom highlight name
 require'nvim_context_vt'.setup{
-  highlight = 'ContextVt',
+  highlight = 'CustomContextVt',
 }
 ```


### PR DESCRIPTION
Defines a vim highlight group named 'ContextVt' so that themes can
provide custom colors without going through 'setup()' of this plugin.

This links the same color as before and keeps the name as instructed by
the README file, so this should not be a BREAKING CHANGE for most users.