### PR TITLE
refactor: use snake_case code style

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ require('nvim_context_vt').setup({
 
 ## Debug
 
-If a context expected is not shown you can try to use `:lua require 'nvim_context_vt'.showDebug()`
+If a context expected is not shown you can try to use `:lua require 'nvim_context_vt'.show_debug()`
 to get current and parent node info.
 
 ## License

--- a/plugin/nvim_context_vt.vim
+++ b/plugin/nvim_context_vt.vim
@@ -1,4 +1,4 @@
 highlight default link ContextVt Comment
 
-autocmd CursorMoved  * lua require 'nvim_context_vt'.showContext()
-autocmd CursorMovedI * lua require 'nvim_context_vt'.showContext()
+autocmd CursorMoved  * lua require 'nvim_context_vt'.show_context()
+autocmd CursorMovedI * lua require 'nvim_context_vt'.show_context()


### PR DESCRIPTION
This seems to be the style used in the neovim ecoystem (with exception of things like "classes" and "enums" definitions).

What do you think about this @haringsrob ?

*Edit* Fixed the camel typo :joy: 