### PR TITLE
Node traversal (and debugging) improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ require('nvim_context_vt').setup({
 
   -- Callback to override the generated virtual text.
   -- You can also use this to filter out node types.
-  custom_text_handler = function(node, ts_utils)
+  custom_text_handler = function(node, ts_utils, ft)
     -- If you return `nil`, no virtual text will be displayed.
     if node:type() == 'function' then
       return nil


### PR DESCRIPTION
~~Adds a couple of new targets, but more importantly:~~

*Edit: I cherry-picked these into master*

---

Separates node traversal into a separate function that constructs a very
basic table structure that can be used to determine what node to show in
cases where there are multiple per line.

Currently this uses the last node on the line, which is the reverse of
the changes made in #19, but will be more accurate.

This can be expanded upon by adding resolvers for spesific languages
etc.

The debugging feature now also uses this function to get more detailed
output.

---

Example of how this improved the virtual text (typescript example, after the ddition of lexical declerations which would only work with the new changes):

**Before:**

![before](https://user-images.githubusercontent.com/161548/149409397-0953b0ba-f831-4668-8a3f-30ac63fb62a1.png)


**After:**

![after](https://user-images.githubusercontent.com/161548/149409412-8690113e-d517-4ef9-8d2a-0060719b939e.png)


---

Example output of new debug log (from the above example):

```
   25:arrow_function --> (value: number, el: HTMLElement) => {
   25:lexical_declaration --> const offsetReducer = (value: number, el: HTMLElement) => {
134:function_declaration --> function scrollSpy(
```

Now shows the line number, node type and virtual text, as well as indented.