### PR TITLE
feat: improved language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ require('nvim_context_vt').setup({
   -- Default: {}
   disable_ft = { 'markdown' },
 
+  -- Disable display of virtual text below blocks for indentation based languages like Python
+  -- Default: false
+  disable_virtual_lines = false,
+
+  -- Same as above but only for spesific filetypes
+  -- Default: {}
+  disable_virtual_lines_ft = { 'yaml' },
+
   -- How many lines required after starting position to show virtual text
   -- Default: 1 (equals two lines total)
   min_rows = 1,
@@ -57,7 +65,6 @@ require('nvim_context_vt').setup({
 
     return true
   end,
-
 
   -- Custom node virtual text resolver callback
   -- Default: nil

--- a/doc/nvim_context_vt.txt
+++ b/doc/nvim_context_vt.txt
@@ -35,6 +35,14 @@ To customize the behavior use the setup function:
       -- Default: {}
       disable_ft = { 'markdown' },
 
+      -- Disable display of virtual text below blocks for indentation based languages like Python
+      -- Default: false
+      disable_virtual_lines = false,
+
+      -- Same as above but only for spesific filetypes
+      -- Default: {}
+      disable_virtual_lines_ft = { 'yaml' },
+
       -- How many lines required after starting position to show virtual text
       -- Default: 1 (equals two lines total)
       min_rows = 1,


### PR DESCRIPTION
@haringsrob I recently was messing around with Python and noticed that this plugin didn't really work with languages like that, so I came up with this solution.

Since this adds actual new virtual lines I thought I should ask you if this should be something that is disabled by default?

Attached some screenshots and videos to illustrate what I mean here.

## Commit

```
Certain languages like Python does not use brackets etc to close a
block.

This adds support for showing virtual texts in these contexts after the
ending lines instead of on the ending line which makes things much
easier to understand.
```

## Before

![before](https://user-images.githubusercontent.com/161548/150876471-569d6890-9f7c-4d2d-b652-ab5ec21735a5.png)

https://user-images.githubusercontent.com/161548/150876244-1e525ad5-be2d-4b7a-adfe-71dc94215b18.mp4

## After

![after](https://user-images.githubusercontent.com/161548/150876457-77ce26c0-999b-4ca0-a0a6-31767e397a72.png)

https://user-images.githubusercontent.com/161548/150876255-3c104017-07c9-4aa1-8eed-e38733eb1461.mp4
