### PR TITLE
feat: add vim command to toggle enabled state

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ require('nvim_context_vt').setup({
 })
 ```
 
+## Commands
+
+* `:NvimContextVtToggle` - Enable/disable context virtual text
+
 ## Debug
 
 If you don't see the expected context vitual text, run `:NvimContextVtDebug` to print out the

--- a/doc/nvim_context_vt.txt
+++ b/doc/nvim_context_vt.txt
@@ -8,8 +8,9 @@ CONTENTS                                                *nvim_context_vt-content
 1. nvim_context_vt...............................................|nvim_context_vt|
     1.1. How to install..................................|nvim_context_vt-install|
     1.2. Advanced usage.................................|nvim_context_vt-advanced|
-    1.3. Debug.............................................|nvim_context_vt-debug|
-    1.4. License.........................................|nvim_context_vt-license|
+    1.3. Commands.......................................|nvim_context_vt-commands|
+    1.4. Debug.............................................|nvim_context_vt-debug|
+    1.5. License.........................................|nvim_context_vt-license|
 
 --------------------------------------------------------------------------------
 HOW TO INSTALL                                           *nvim_context_vt-install*
@@ -86,6 +87,11 @@ To customize the behavior use the setup function:
       end,
     })
 <
+
+--------------------------------------------------------------------------------
+COMMANDS                                                *nvim_context_vt-commands*
+
+* `:NvimContextVtToggle` - Enable/disable context virtual text
 
 --------------------------------------------------------------------------------
 DEBUG                                                      *nvim_context_vt-debug*

--- a/lua/nvim_context_vt/init.lua
+++ b/lua/nvim_context_vt/init.lua
@@ -5,6 +5,7 @@ local utils = require('nvim_context_vt.utils')
 local M = {}
 local ns = vim.api.nvim_create_namespace('context_vt')
 local opts = config.default_opts
+local enabled = true
 
 function M.setup(user_opts)
     opts = vim.tbl_extend('force', config.default_opts, user_opts or {})
@@ -29,9 +30,19 @@ function M.show_debug()
     end
 end
 
+function M.toggle_context()
+    if enabled then
+        enabled = false
+        vim.api.nvim_buf_clear_namespace(0, ns, 0, -1)
+    else
+        enabled = true
+        M.show_context()
+    end
+end
+
 function M.show_context()
     local ft = parsers.get_buf_lang()
-    if vim.tbl_contains(opts.disable_ft, ft) then
+    if not enabled or vim.tbl_contains(opts.disable_ft, ft) then
         return
     end
 

--- a/plugin/nvim_context_vt.vim
+++ b/plugin/nvim_context_vt.vim
@@ -1,6 +1,7 @@
 highlight default link ContextVt Comment
 
 command NvimContextVtDebug lua require'nvim_context_vt'.show_debug()
+command NvimContextVtToggle lua require'nvim_context_vt'.toggle_context()
 
 autocmd CursorMoved  * lua require 'nvim_context_vt'.show_context()
 autocmd CursorMovedI * lua require 'nvim_context_vt'.show_context()


### PR DESCRIPTION
Adds the command `:NvimContextVtToggle` to toggle the enabled state for
showing virtual text.

closes #53