### PR TITLE
fix get_node_text import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ require('nvim_context_vt').setup({
   -- Custom virtual text node parser callback
   -- Default: nil
   custom_parser = function(node, ft, opts)
-    local ts_utils = require('nvim-treesitter.ts_utils')
+    local ts_query = require('nvim-treesitter.query')
 
     -- If you return `nil`, no virtual text will be displayed.
     if node:type() == 'function' then
@@ -58,7 +58,7 @@ require('nvim_context_vt').setup({
     end
 
     -- This is the standard text
-    return '--> ' .. ts_utils.get_node_text(node)[1]
+    return '--> ' .. ts_query.get_node_text(node)[1]
   end,
 
   -- Custom node validator callback

--- a/doc/nvim_context_vt.txt
+++ b/doc/nvim_context_vt.txt
@@ -60,13 +60,14 @@ To customize the behavior use the setup function:
       -- Default: nil
       custom_parser = function(node, ft, opts)
         local ts_utils = require('nvim-treesitter.ts_utils')
+        local ts_query = require('nvim-treesitter.query')
 
         -- If you return `nil`, no virtual text will be displayed.
         if node:type() == 'function' then
           return nil
         end
         -- This is the standard text
-        return '--> ' .. ts_utils.get_node_text(node)[1]
+        return '--> ' .. ts_query.get_node_text(node)[1]
       end,
 
       -- Custom node validator callback

--- a/lua/nvim_context_vt/utils.lua
+++ b/lua/nvim_context_vt/utils.lua
@@ -1,9 +1,9 @@
-local ts_utils = require('nvim-treesitter.ts_utils')
+local ts_query = require('nvim-treesitter.query')
 local config = require('nvim_context_vt.config')
 local M = {}
 
 M.default_parser = function(node, _, opts)
-    return opts.prefix .. ' ' .. ts_utils.get_node_text(node, 0)[1]
+    return opts.prefix .. ' ' .. ts_query.get_node_text(node, 0)[1]
 end
 
 M.default_validator = function(node, ft, opts)
@@ -20,7 +20,7 @@ end
 
 M.find_virtual_text_nodes = function(validator, ft, opts)
     local result = {}
-    local node = ts_utils.get_node_at_cursor()
+    local node = ts_query.get_node_at_cursor()
 
     while node ~= nil and not vim.tbl_contains(config.ignore_root_targets, node:type()) do
         if validator(node, ft, opts) then


### PR DESCRIPTION
When using this plugin in neovim 0.7.0, it says
`nvim-treesitter.ts_utils.get_node_text is deprecated: use vim.treesitter.query.get_node_text`
so I made a PR