### PR TITLE
feat: improve virtual text highlight when 'cursorline' set

### DIFF
--- a/lua/nvim_context_vt/utils.lua
+++ b/lua/nvim_context_vt/utils.lua
@@ -78,7 +78,7 @@ M.create_virtual_text_factory = function(parser, ft, opts)
     local function text_from_node(node)
         local vt = parser(node, ft, opts)
         if vt then
-            return { virt_text = { { vt, opts.highlight } } }
+            return { virt_text = { { vt, opts.highlight } }, hl_mode = 'combine' }
         end
         return nil
     end
@@ -91,7 +91,7 @@ M.create_virtual_text_factory = function(parser, ft, opts)
 
             local lines = lines_from_nodes(nodes)
             if #lines > 0 then
-                return { virt_lines = lines }
+                return { virt_lines = lines, hl_mode = 'combine' }
             end
         end
 


### PR DESCRIPTION
Hi,

This PR set virtual text highlight mode to `combine`.

Before
![image](https://github.com/haringsrob/nvim_context_vt/assets/90168447/54d580e9-5892-4390-8fba-03eacb667bfa)


After
![image](https://github.com/haringsrob/nvim_context_vt/assets/90168447/98fb8649-77b4-440a-851f-3eca65e79ef6)
