### PR TITLE
Remove nvim ts dependency

### DIFF
--- a/lua/nvim_context_vt/init.lua
+++ b/lua/nvim_context_vt/init.lua
@@ -1,4 +1,3 @@
-local parsers = require('nvim-treesitter.parsers')
 local config = require('nvim_context_vt.config')
 local utils = require('nvim_context_vt.utils')
 
@@ -10,8 +9,26 @@ function M.setup(user_opts)
     opts = vim.tbl_extend('force', config.default_opts, user_opts or {})
 end
 
+function M.ft_to_lang(ft)
+    local result = vim.treesitter.language.get_lang(ft)
+    if result then
+        return result
+    else
+        ft = vim.split(ft, '.', { plain = true })[1]
+        return vim.treesitter.language.get_lang(ft) or ft
+    end
+end
+
+--- Gets the language of a given buffer
+---@param bufnr number? or current buffer
+---@return string
+function M.get_buf_lang(bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+    return M.ft_to_lang(vim.api.nvim_buf_get_option(bufnr, 'ft'))
+end
+
 function M.show_debug()
-    local ft = parsers.get_buf_lang()
+    local ft = M.get_buf_lang()
     local result = utils.find_virtual_text_nodes(function()
         return true
     end, ft, opts)
@@ -40,7 +57,7 @@ function M.toggle_context()
 end
 
 function M.show_context()
-    local ft = parsers.get_buf_lang()
+    local ft = M.get_buf_lang()
     if not opts.enabled or vim.tbl_contains(opts.disable_ft, ft) then
         return
     end

--- a/lua/nvim_context_vt/init.lua
+++ b/lua/nvim_context_vt/init.lua
@@ -33,7 +33,9 @@ function M.show_debug()
         return true
     end, ft, opts)
 
+    ---@type TSNode[][]
     local values = vim.tbl_values(result)
+    ---@type number[]
     local lines = vim.tbl_keys(result)
 
     for index, nodes in ipairs(values) do

--- a/lua/nvim_context_vt/utils.lua
+++ b/lua/nvim_context_vt/utils.lua
@@ -26,7 +26,12 @@ M.default_parser = function(node, _, opts)
     return opts.prefix .. ' ' .. M.get_node_text(node, 0)[1]
 end
 
+---@param node TSNode
+---@param ft string
+---@param opts table
+---@return boolean
 M.default_validator = function(node, ft, opts)
+    ---@type integer
     local min_rows = opts.min_rows_ft[ft] or opts.min_rows
     if vim.tbl_contains(config.targets, node:type()) then
         return node:end_() > node:start() + min_rows
@@ -34,12 +39,18 @@ M.default_validator = function(node, ft, opts)
     return false
 end
 
+---@param nodes TSNode[]
+---@return TSNode
 M.default_resolver = function(nodes)
     return nodes[#nodes]
 end
 
+---@param validator fun(node: TSNode, ft: string, opts: table): boolean
+---@param ft string
+---@param opts table
+---@return table<number, table<number, TSNode>>
 M.find_virtual_text_nodes = function(validator, ft, opts)
-    local result = {}
+    local result = {} ---@type table<number, table<number, TSNode>>
     local node = vim.treesitter.get_node()
 
     while node ~= nil and not vim.tbl_contains(config.ignore_root_targets, node:type()) do
@@ -57,10 +68,16 @@ M.find_virtual_text_nodes = function(validator, ft, opts)
     return result
 end
 
+---@param parser fun(node: TSNode, ft: string, opts: table): string
+---@param ft string
+---@param opts table
+---@return fun(node: TSNode, nodes: TSNode[]): table?
 M.create_virtual_text_factory = function(parser, ft, opts)
     local is_line_ft = vim.tbl_contains(config.line_ft, ft)
     local skip_line_ft = opts.disable_virtual_lines or vim.tbl_contains(opts.disable_virtual_lines_ft, ft)
 
+    ---@param nodes TSNode[]
+    ---@return table
     local function lines_from_nodes(nodes)
         local lines = {}
         for _, n in ipairs(nodes) do
@@ -74,6 +91,8 @@ M.create_virtual_text_factory = function(parser, ft, opts)
         return lines
     end
 
+    ---@param node TSNode
+    ---@return table?
     local function text_from_node(node)
         local vt = parser(node, ft, opts)
         if vt then

--- a/lua/nvim_context_vt/utils.lua
+++ b/lua/nvim_context_vt/utils.lua
@@ -1,4 +1,3 @@
-local ts_utils = require('nvim-treesitter.ts_utils')
 local config = require('nvim_context_vt.config')
 local M = {}
 
@@ -41,7 +40,7 @@ end
 
 M.find_virtual_text_nodes = function(validator, ft, opts)
     local result = {}
-    local node = ts_utils.get_node_at_cursor()
+    local node = vim.treesitter.get_node()
 
     while node ~= nil and not vim.tbl_contains(config.ignore_root_targets, node:type()) do
         if validator(node, ft, opts) then


### PR DESCRIPTION
In the new main branch for nvim-ts, the utils and such are removed, and master will be deprecated probably when 0.10 releases - this might raise the minimum neovim requirement but that's better than a dependency that will be deprecated imo