### PR TITLE
feat: hide_context fn

### DIFF
--- a/lua/nvim_context_vt/init.lua
+++ b/lua/nvim_context_vt/init.lua
@@ -51,7 +51,7 @@ end
 function M.toggle_context()
     if opts.enabled then
         opts.enabled = false
-        vim.api.nvim_buf_clear_namespace(0, ns, 0, -1)
+        M.hide_context()
     else
         opts.enabled = true
         M.show_context()
@@ -81,6 +81,10 @@ function M.show_context()
             vim.api.nvim_buf_set_extmark(0, ns, line, 0, vt)
         end
     end
+end
+
+function M.hide_context()
+    vim.api.nvim_buf_clear_namespace(0, ns, 0, -1)
 end
 
 return M


### PR DESCRIPTION
I want to explicitly hide or show context virtual texts, `M.toggle_context()` is not covering that case, as I can't provide the state I want it to be in.

Not sure whether this is enough, or whether I should also set opts.enabled in each fn, similar to what `M.toggle_context()` does, but instead in their respective methods.