### PR TITLE
fix: dead loop

### DIFF
--- a/lua/nvim_context_vt/utils.lua
+++ b/lua/nvim_context_vt/utils.lua
@@ -65,7 +65,13 @@ M.find_virtual_text_nodes = function(validator, ft, opts)
             table.insert(result[target_line], node)
         end
 
-        node = node:parent()
+        local pnode = node:parent()
+        if pnode == node then
+            -- in case of dead loop
+            break
+        else
+            node = pnode
+        end
     end
 
     return result


### PR DESCRIPTION

<img width="245" alt="image" src="https://github.com/user-attachments/assets/0d294f1b-fb3a-4536-b502-9eba7f2c1beb">


press `backspace` here, get dead loop.

```txt
msg_show   version NVIM v0.10.2
msg_show   version Build type: Release
msg_show   version LuaJIT 2.1.1731601260
```