### PR TITLE
Make virtual text priority configurable (and default to 1000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ require('nvim_context_vt').setup({
   -- Default: '-->'
   prefix = '',
 
+  -- Override default virtual text priority
+  -- Default: 1000
+  priority = 1000,
+
   -- Override the internal highlight group name
   -- Default: 'ContextVt'
   highlight = 'CustomContextVt',

--- a/lua/nvim_context_vt/config.lua
+++ b/lua/nvim_context_vt/config.lua
@@ -12,6 +12,7 @@ M.default_opts = {
     disable_virtual_lines = false,
     disable_virtual_lines_ft = {},
     prefix = '-->',
+    priority = 1000,
 }
 
 M.targets = {

--- a/lua/nvim_context_vt/init.lua
+++ b/lua/nvim_context_vt/init.lua
@@ -78,6 +78,7 @@ function M.show_context()
         local vt = create_vt(node, nodes)
 
         if vt then
+            vt.priority = opts.priority
             vim.api.nvim_buf_set_extmark(0, ns, line, 0, vt)
         end
     end


### PR DESCRIPTION
This small change makes the virtual text priority as a configurable option (and default its value to 1000 if not specified). 
This allows for much more flexibility when using this plugin along with other plugins that can work on the same line, allowing us to decide which one should have higher priority when writing its output.